### PR TITLE
chore: pin GitHub actions with their SHA-1 instead of their version number

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,10 +1,7 @@
----
 name: Update Docs
-
 on:
   schedule:
     - cron: "*/15 * * * *"
-
 jobs:
   build:
     name: Update Docs
@@ -12,20 +9,17 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v2
-
       - name: Update
-        uses: docker://jnorwood/helm-docs:latest
+        uses: docker://index.docker.io/jnorwood/helm-docs@sha256:66c8f4164dec860fa5c1528239c4aa826a12485305b7b224594b1a73f7e6879a # ratchet:docker://jnorwood/helm-docs:latest
         with:
           entrypoint: helm-docs
-
       - name: Debug
         run: |
           git diff
           git status
-
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@18f7dc018cc2cd597073088f7c7591b9d1c02672 # v3
         with:
           commit-message: 'chore(docs): regenerated helm docs'
           signoff: false

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,8 +1,6 @@
----
 name: Build and test Go
 on:
   pull_request:
-
 jobs:
   build:
     name: Build
@@ -12,12 +10,9 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
       - name: Check out source code
         uses: actions/checkout@v2
-
       - name: Build
         run: make build
-
       - name: Test
         run: make test

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,8 +1,6 @@
----
 name: golangci-lint
 on:
   pull_request:
-
 jobs:
   golangci:
     name: lint
@@ -10,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.28

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,11 +1,8 @@
----
 name: goreleaser
-
 on:
   push:
     branches:
       - main
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -14,17 +11,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1
         with:
           version: v3.5.2
-
       - name: Prepare
         id: prep
         run: |
@@ -57,30 +51,25 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.4.1
+        uses: goreleaser/goreleaser-action@56f5b77f7fa4a8fe068bf22b732ec036cc9bc13f # v2.4.1
         with:
           version: latest
           args: ${{ steps.prep.outputs.goreleaser_args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           push: true
@@ -91,27 +80,23 @@ jobs:
             org.opencontainers.image.url=${{ github.event.repository.html_url }}
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
-
       - name: Configure Git
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Update appVersion in Chart.yaml
-        uses: mikefarah/yq@v4.6.0
+        uses: mikefarah/yq@111c6e0be18ffde03c9fd51066f5eed5d12f0703 # v4.6.0
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         with:
           cmd: yq eval '.appVersion = "${{ steps.prep.outputs.version }}"' -i charts/captain-hook/Chart.yaml
-
       - name: Update version in Chart.yaml
-        uses: mikefarah/yq@v4.6.0
+        uses: mikefarah/yq@111c6e0be18ffde03c9fd51066f5eed5d12f0703 # v4.6.0
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         with:
           cmd: yq eval '.version = "${{ steps.prep.outputs.version }}"' -i charts/captain-hook/Chart.yaml
-
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         with:
           version: v3.5.2

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,9 +1,6 @@
----
 name: goreleaser
-
 on:
   pull_request:
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -12,21 +9,17 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1
         with:
           version: v3.5.2
-
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-
       - name: Prepare
         id: prep
         run: |
@@ -59,9 +52,8 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.4.1
+        uses: goreleaser/goreleaser-action@56f5b77f7fa4a8fe068bf22b732ec036cc9bc13f # v2.4.1
         with:
           version: latest
           args: ${{ steps.prep.outputs.goreleaser_args }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,8 @@
----
 name: goreleaser
-
 on:
   push:
     tags:
       - '*'
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -14,12 +11,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-
       - name: Prepare
         id: prep
         run: |
@@ -52,30 +47,25 @@ jobs:
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2.4.1
+        uses: goreleaser/goreleaser-action@56f5b77f7fa4a8fe068bf22b732ec036cc9bc13f # v2.4.1
         with:
           version: latest
           args: ${{ steps.prep.outputs.goreleaser_args }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7 # v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2
         with:
           context: .
           push: true
@@ -91,33 +81,28 @@ jobs:
             org.label-schema.build-date=${{ steps.prep.outputs.created }}
             org.label-schema.vcs-ref=${{ github.sha }}
             inspect.tree.state=clean
-
       - name: Configure Git
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         run: |
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-
       - name: Update appVersion in Chart.yaml
-        uses: mikefarah/yq@v4.6.0
+        uses: mikefarah/yq@111c6e0be18ffde03c9fd51066f5eed5d12f0703 # v4.6.0
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         with:
           cmd: yq eval '.appVersion = "${{ steps.prep.outputs.version }}"' -i charts/captain-hook/Chart.yaml
-
       - name: Update version in Chart.yaml
-        uses: mikefarah/yq@v4.6.0
+        uses: mikefarah/yq@111c6e0be18ffde03c9fd51066f5eed5d12f0703 # v4.6.0
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         with:
           cmd: yq eval '.version = "${{ steps.prep.outputs.version }}"' -i charts/captain-hook/Chart.yaml
-
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         with:
           version: v3.5.2
-
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@120944e66390c2534cc1b3c62d7285ba7ff02594 # v1.2.0
         if: ${{ steps.prep.outputs.release_chart == 'true' }}
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Ref: https://github.com/jenkins-infra/helpdesk/issues/3402